### PR TITLE
fix: quote single quote in `Exec` key

### DIFF
--- a/misc/qlp-mime.desktop
+++ b/misc/qlp-mime.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=QLivePlayer Mime
 NoDisplay=true
-Exec=env LD_LIBRARY_PATH='' qlphelper -u %u --quiet
+Exec=env "LD_LIBRARY_PATH=''" qlphelper -u %u --quiet
 Icon=qliveplayer
 Type=Application
 MimeType=x-scheme-handler/qliveplayer;


### PR DESCRIPTION
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables

This patch fixes a [bug](https://bugs.gentoo.org/818118) on Gentoo CI.